### PR TITLE
Change language navbar behaviour

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -12,6 +12,7 @@ placeholder = "Search..."
 
 [header]
 darkmode_toggle = "Toggle dark mode"
+no_translation = "No translations available"
 
 [404]
 go_back_home = "Go back home"

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -12,6 +12,7 @@ placeholder = "Buscar..."
 
 [header]
 darkmode_toggle = "Cambiar a modo oscuro"
+no_translation = "No hay traducciones disponibles"
 
 [404]
 go_back_home = "Volver al inicio"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -12,6 +12,7 @@ placeholder = "Rechercher..."
 
 [header]
 darkmode_toggle = "Activer le mode sombre"
+no_translation = "Aucune traduction disponible"
 
 [404]
 go_back_home = "Revenir à l'accueil"

--- a/i18n/hi.toml
+++ b/i18n/hi.toml
@@ -12,6 +12,7 @@ placeholder = "खोजें..."
 
 [header]
 darkmode_toggle = "डार्क मोड टॉगल करें"
+no_translation = "कोई अनुवाद उपलब्ध नहीं"
 
 [404]
 go_back_home = "होम पर वापस जाएं"

--- a/i18n/jp.toml
+++ b/i18n/jp.toml
@@ -12,6 +12,7 @@ placeholder = "検索..."
 
 [header]
 darkmode_toggle = "ダークモードを切り替える"
+no_translation = "他の言語はありません"
 
 [404]
 go_back_home = "ホームに戻る"

--- a/i18n/pl.toml
+++ b/i18n/pl.toml
@@ -13,6 +13,7 @@ placeholder = "Szukaj..."
 
 [header]
 darkmode_toggle = "Przełącz ciemny motyw"
+no_translation = "Brak dostępnych tłumaczeń"
 
 [404]
 go_back_home = "Powrót do strony głównej"

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -12,6 +12,7 @@ placeholder = "Поиск..."
 
 [header]
 darkmode_toggle = "Включить темный режим"
+no_translation = "Нет доступных переводов"
 
 [404]
 go_back_home = "Вернуться на главную"

--- a/i18n/zh-CN.toml
+++ b/i18n/zh-CN.toml
@@ -12,6 +12,7 @@ placeholder = "搜索..."
 
 [header]
 darkmode_toggle = "切换夜间模式"
+no_translation = "没有可用的翻译"
 
 [404]
 go_back_home = "回到首页"

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -19,7 +19,7 @@
       </button>
       <div class="absolute hidden top-16 z-50" id="navbar-lang">
         <ul class="flex flex-col rounded-sm px-3 text-base font-medium text-slate-800 dark:text-slate-200 shadow-lg bg-white dark:bg-gray-600 shadow-slate-800/5 dark:shadow-slate-200/5 ring-1 ring-slate-900/5 dark:ring-slate-100/5">
-        {{  range .Translations }}
+        {{ range .Translations }}
           <li class="">
             <a class="block px-3 py-3 hover:text-emerald-600"
               href="{{ .RelPermalink }}" title="{{ .Language.LanguageName }}">{{ .Language.LanguageName }}</a>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -8,7 +8,7 @@
   <div class="flex-none">
     {{ partial "menu.html" . }}
   </div>
-  {{ if (gt .Site.Home.AllTranslations.Len 1) }}
+  {{ if .IsTranslated }}
   <div class="flex-none">
     <div class="h-full static">
       <button id="navbar-lang-toggle" type="button" class="inline-flex items-center p-2 text-sm text-slate-800 dark:text-slate-200 rounded-lg" aria-controls="navbar-menu" aria-expanded="false">
@@ -19,7 +19,7 @@
       </button>
       <div class="absolute hidden top-16 z-50" id="navbar-lang">
         <ul class="flex flex-col rounded-sm px-3 text-base font-medium text-slate-800 dark:text-slate-200 shadow-lg bg-white dark:bg-gray-600 shadow-slate-800/5 dark:shadow-slate-200/5 ring-1 ring-slate-900/5 dark:ring-slate-100/5">
-        {{ range .Site.Home.AllTranslations.ByWeight }}
+        {{  range .Translations }}
           <li class="">
             <a class="block px-3 py-3 hover:text-emerald-600"
               href="{{ .RelPermalink }}" title="{{ .Language.LanguageName }}">{{ .Language.LanguageName }}</a>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -8,7 +8,7 @@
   <div class="flex-none">
     {{ partial "menu.html" . }}
   </div>
-  {{ if .IsTranslated }}
+  {{ if (gt .Site.Home.AllTranslations.Len 1) }}
   <div class="flex-none">
     <div class="h-full static">
       <button id="navbar-lang-toggle" type="button" class="inline-flex items-center p-2 text-sm text-slate-800 dark:text-slate-200 rounded-lg" aria-controls="navbar-menu" aria-expanded="false">
@@ -19,12 +19,18 @@
       </button>
       <div class="absolute hidden top-16 z-50" id="navbar-lang">
         <ul class="flex flex-col rounded-sm px-3 text-base font-medium text-slate-800 dark:text-slate-200 shadow-lg bg-white dark:bg-gray-600 shadow-slate-800/5 dark:shadow-slate-200/5 ring-1 ring-slate-900/5 dark:ring-slate-100/5">
-        {{ range .Translations }}
-          <li class="">
-            <a class="block px-3 py-3 hover:text-emerald-600"
-              href="{{ .RelPermalink }}" title="{{ .Language.LanguageName }}">{{ .Language.LanguageName }}</a>
-          </li>
-        {{ end }}
+        {{ if .IsTranslated }}
+			{{ range .Translations }}
+				<li class="">
+					<a class="block px-3 py-3 hover:text-emerald-600"
+					href="{{ .RelPermalink }}" title="{{ .Language.LanguageName }}">{{ .Language.LanguageName }}</a>
+				</li>
+			{{ end }}
+		{{ else }}
+				<li class="">
+					<i class="block px-3 py-3">{{ T "header.no_translation" }}</i>
+				</li>
+		{{ end }}
         </ul>
       </div>
     </div>


### PR DESCRIPTION
I think that redirecting to the homepage when changing the language can be irritating for the reader. This PR changes the way link are generated so that the lead to the translated page.

A list of all available languages is still generated on the homepage