### PR TITLE
Fix reading time plural rules for polish translation

### DIFF
--- a/i18n/pl.toml
+++ b/i18n/pl.toml
@@ -3,7 +3,8 @@ open_main_menu = "Otwórz menu główne"
 open_lang_switcher = "Zmień język"
 [reading_time]
   one = "Jedna minuta czytania"
-  other = "{{ .Count }} minut(y) czytania"
+  many = "{{ .Count }} minut czytania"
+  other = "{{ .Count }} minuty czytania"
 
 [search]
 title = "Szukaj"


### PR DESCRIPTION
This PR makes separate strings for "many" and "other" forms 