### PR TITLE
Render svg images from markdown

### DIFF
--- a/exampleSite/content/post/image-process/index.md
+++ b/exampleSite/content/post/image-process/index.md
@@ -12,6 +12,8 @@ image = "images/hugo-logo-wide.svg"
 
 ![placeholder](https://placeholder.co/1024x768/png "Test for external image")
 
+![svg](./images/hugo-logo-wide.svg "Test for svg")
+
 <p align="center" width="100%">
     <img src="./images/logo.png">
 </p>

--- a/exampleSite/content/post/image-process/index.zh-cn.md
+++ b/exampleSite/content/post/image-process/index.zh-cn.md
@@ -11,3 +11,9 @@ image = "images/hugo-logo-wide.svg"
 ![Photo by Behnam Norouzi on Unsplash](./images/behnam-norouzi-_1ok63FFlM4-unsplash.jpg "Photo by Behnam Norouzi on Unsplash")
 
 ![placeholder](https://placeholder.co/1024x768/png "Test for external image")
+
+![svg](./images/hugo-logo-wide.svg "Test for svg")
+
+<p align="center" width="100%">
+    <img src="./images/logo.png">
+</p>

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -12,7 +12,7 @@
 
 <div class="not-prose">
 <!-- check if it exists as a page resource -->
-{{- with .Page.Resources.Get $dest -}}
+{{- with and (ne (.Page.Resources.Get $dest).MediaType.SubType "svg") (.Page.Resources.Get $dest) -}}
 {{- $src := . -}}
 {{- $dataSzes := "(min-width: 1024px) 100vw, 50vw" -}}
 {{- $actualImg := $src.Resize (print "640x jpg " $filter) -}}


### PR DESCRIPTION
Hi,
this PR will allow users to define an svg in Markdown:   
```![svg](./images/hugo-logo-wide.svg "Test for svg")```  

The current render-image.html tries to resize the given image. This is not possible for a svg and will raise an error:  
```execute of template failed at <$src.Resize>: error calling Resize: this method is only available for raster images.```  

So, I added a check for MediaSubType and will default to "normal" html img tag when svg is detected. 
In the final rendered html view the svg will shrink to the size of the parent container if width is set on the svg and is wider than the parent.