### PR TITLE
fix: custom title for taxonomies

### DIFF
--- a/exampleSite/content/categories/with-slug/_index.md
+++ b/exampleSite/content/categories/with-slug/_index.md
@@ -1,0 +1,4 @@
+---
+title: A Category with Slug
+slug: with-slug
+---

--- a/exampleSite/content/categories/with-slug/_index.zh-cn.md
+++ b/exampleSite/content/categories/with-slug/_index.zh-cn.md
@@ -1,0 +1,4 @@
+---
+title: 自定义 Slug 的分类
+slug: with-slug
+---

--- a/exampleSite/content/post/image-process/index.md
+++ b/exampleSite/content/post/image-process/index.md
@@ -3,9 +3,10 @@ author = "Hugo Authors"
 title = "Image Process"
 date = "2023-12-01"
 description = "Demo of Hugo's image processing"
-tags = []
+tags = ["custom"]
 toc = false
 image = "images/hugo-logo-wide.svg"
+categories = ["with-slug"]
 +++
 
 ![Photo by Behnam Norouzi on Unsplash](./images/behnam-norouzi-_1ok63FFlM4-unsplash.jpg "Photo by Behnam Norouzi on Unsplash")

--- a/exampleSite/content/post/image-process/index.zh-cn.md
+++ b/exampleSite/content/post/image-process/index.zh-cn.md
@@ -3,9 +3,10 @@ author = "Hugo Authors"
 title = "图片处理"
 date = "2023-12-01"
 description = "关于Hugo中图片处理的示例"
-tags = []
+tags = ["custom"]
 toc = false
 image = "images/hugo-logo-wide.svg"
+categories = ["with-slug"]
 +++
 
 ![Photo by Behnam Norouzi on Unsplash](./images/behnam-norouzi-_1ok63FFlM4-unsplash.jpg "Photo by Behnam Norouzi on Unsplash")

--- a/exampleSite/content/tags/custom/_index.md
+++ b/exampleSite/content/tags/custom/_index.md
@@ -1,0 +1,4 @@
+---
+title: CustomTag
+slug: custom
+---

--- a/exampleSite/content/tags/custom/_index.zh-cn.md
+++ b/exampleSite/content/tags/custom/_index.zh-cn.md
@@ -1,0 +1,4 @@
+---
+title: 随便一个标签
+slug: custom
+---

--- a/layouts/partials/block/taxonomies.html
+++ b/layouts/partials/block/taxonomies.html
@@ -1,24 +1,24 @@
 {{ if (or .Params.categories .Params.tags) }}
   <ul class="flex flex-row flex-wrap text-slate-500 dark:text-slate-300">
     {{ if .Params.categories }}
-      {{ range .Params.categories }}
+      {{ range (.GetTerms "categories") }}
       <li>
         <a href="{{ (urlize (printf "categories/%s" . )) | relLangURL }}/"
           class="text-sm mr-2 px-2 py-1 rounded border border-emerald-800 bg-emerald-800 text-slate-50">
-          {{ . }}
+          {{ .LinkTitle }}
         </a>
       </li>
       {{ end }}
     {{ end }}
     {{ if .Params.tags }}
-      {{ range .Params.tags }}
+      {{ range (.GetTerms "tags") }}
       <li>
         <a href="{{ (urlize (printf "tags/%s" . )) | relLangURL }}/"
           class="flex flex-row text-sm mr-2 py-1">
           <i class="h-5 w-5 flex-none">
             {{ partial "icon.html" site.Params.taxonomies.icons.tags }}
           </i>
-          <span class="ml-0">{{ . }}</span>
+          <span class="ml-0">{{ .LinkTitle }}</span>
         </a>
       </li>
       {{ end }}


### PR DESCRIPTION
If you have title in a taxonomy, the title is lost in the list and single page, also leads to a mismatch with the sidebar.

This commit fixed this issue. Preview is provided below.

Before:
![image](https://github.com/tomowang/hugo-theme-tailwind/assets/24890691/eda87f06-c6b5-4300-a023-b4940b717b4b)

After:
![image](https://github.com/tomowang/hugo-theme-tailwind/assets/24890691/e2b3e608-fb89-46f0-b342-8a31f348362b)
