### PR TITLE
feat: Support custom sidebar limit param

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -13,6 +13,7 @@
 
 {{ range $taxonomy, $terms := site.Taxonomies }}
   {{ if $terms }}
-  {{ partial "block/sidebar_section.html" (dict "Context" $terms "Taxonomy" $taxonomy "Limit" 10) }}
+  {{- $limit := site.Params.sidebar.limit | default 10 -}}
+  {{ partial "block/sidebar_section.html" (dict "Context" $terms "Taxonomy" $taxonomy "Limit" $limit) }}
   {{ end }}
 {{ end }}


### PR DESCRIPTION
Instead of only ever showing 10 tags, allow the user to set their own custom limit value:

```
# /config/_default/params.toml
[sidebar]
  limit = 100
```