### PR TITLE
 Pass context to custom_head.html and custom_footer.html

### DIFF
--- a/layouts/partials/extended_footer.html
+++ b/layouts/partials/extended_footer.html
@@ -25,4 +25,4 @@
 
 {{ if .Params.asciinema }}{{ partial "asciinema.html" . }}{{ end }}
 
-{{- partial "custom_footer.html" -}}
+{{- partial "custom_footer.html" . -}}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -23,4 +23,4 @@
 <!-- https://gohugo.io/templates/internal/#use-the-google-analytics-template -->
 {{- template "_internal/google_analytics.html" . -}}
 
-{{- partial "custom_head.html" -}}
+{{- partial "custom_head.html" . -}}


### PR DESCRIPTION
I wanted to add

```
{{ with .OutputFormats.Get "rss" -}}
  {{ printf `<link rel=%q type=%q href=%q title=%q>` .Rel .MediaType.Type .Permalink site.Title | safeHTML }}
{{ end }}
```

To `custom_head` as documented [here](https://gohugo.io/templates/rss/), but it wasn't working as the context wasn't passed to `custom_head`.