### PR TITLE
Show progress bar on top

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -26,6 +26,7 @@
   transform-origin: 0 50%;
   animation: grow-progress auto linear;
   animation-timeline: scroll();
+  z-index: 999;
 }
 
 /*


### PR DESCRIPTION
It might get overriden by other page elements, so set explicitly z-index

Before:
![image](https://github.com/user-attachments/assets/3a0ca42f-183f-4992-8055-89adf555530e)

After:
![image](https://github.com/user-attachments/assets/bfa3d622-2408-41f2-a954-288cdecbcb4e)
