### PR TITLE
Fix Russian plural translation

### DIFF
--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -2,7 +2,8 @@ table_of_contents = "Содержание"
 open_main_menu = "Открыть главное меню"
 open_lang_switcher = "Открыть переключатель языка"
 [reading_time]
-  one = "Одну минуту для чтения"
+  one = "{{ .Count }} минуту для чтения"
+  few = "{{ .Count }} минуты для чтения"
   other = "{{ .Count }} минут для чтения"
 
 [search]


### PR DESCRIPTION
Russian has "complex" plural, so more correct translation for reading time should use `few`.

1, 21, 31 - ".. минуту для чтения"
2,3,4, 22 - ".. минуты для чтения"
5,6, 25 - ".. минут для чтения"