### PR TITLE
Fix taxonomy url name used instead of name

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -12,7 +12,7 @@
           <li class="">
             <a href="{{ .RelPermalink }}"
               class="flex flex-row text-slate-600 dark:text-slate-300 backdrop-blur">
-              <span class="text-lg mr-2">{{ $term }}</span>
+              <span class="text-lg mr-2">{{ .LinkTitle }}</span>
               <span class="self-center rounded-full text-xs px-2 bg-red-400 text-white">{{ $count }}</span>
             </a>
           </li>


### PR DESCRIPTION
`.Term` returns something which can be used as machine-readable identifier and/or URL. However for human-readable title it should not be used, so replace it to proper name