### PR TITLE
Add draft indicator

### DIFF
--- a/layouts/partials/block/taxonomies.html
+++ b/layouts/partials/block/taxonomies.html
@@ -1,5 +1,13 @@
 {{ if (or .Params.categories .Params.tags) }}
   <ul class="flex flex-row flex-wrap text-slate-500 dark:text-slate-300">
+    {{ if .Params.draft }}
+      <li>
+        <span 
+          class="text-sm mr-2 px-2 py-1 rounded border border-emerald-800 bg-yellow-400 text-black-50">
+          DRAFT
+        </a>
+      </li>
+    {{ end }}
     {{ if .Params.categories }}
       {{ range (.GetTerms "categories") }}
       <li>


### PR DESCRIPTION
Just came to my mind it would be a cool feature to actually see drafts hightlighted... Not sure it fits your vision of the theme or styling (I wanted to use `bg-red-..` initially, but apparently this wasn't included in the CSS, so I ended up with some yellow), so feel free to correct if something.

Example how it looks:

![image](https://github.com/user-attachments/assets/b8f0688a-0c85-460c-8ea5-8552e4730c52)
