### PR TITLE
Fix search not working on long posts

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -13,7 +13,7 @@
   }
 
   const fuseOptions = {
-    distance: 99999,
+    ignoreLocation: true,
     includeScore: true,
     includeMatches: true,
     minMatchCharLength: searchOptions.minMatchCharLength,

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -13,6 +13,7 @@
   }
 
   const fuseOptions = {
+    distance: 99999,
     includeScore: true,
     includeMatches: true,
     minMatchCharLength: searchOptions.minMatchCharLength,


### PR DESCRIPTION
Default Fuse behavior is to only look into first 100. This doesn't work completely on long posts.