### PR TITLE
Fix depecation warning emitted with hugo 0.156.0

### DIFF
--- a/layouts/search/search.json
+++ b/layouts/search/search.json
@@ -1,5 +1,5 @@
 {{- $.Scratch.Add "index" slice -}}
-{{- range .Site.Sites -}}
+{{- range hugo.Sites -}}
     {{- $pages := where .RegularPages "Params.hidden" "!=" true -}}
     {{- range $pages -}}
         {{- $categories := slice -}}


### PR DESCRIPTION
When running example site with latest released hugo version 0.156.0, a warning is shown:

```
INFO  deprecated: .Site.Sites and .Page.Sites was deprecated in Hugo v0.156.0 and will be removed in a future release.
Use hugo.Sites instead.
```

This PR fixes this issue.